### PR TITLE
Replace libxml-ruby with REXML for a pure-Ruby experience

### DIFF
--- a/simplecov-cobertura.gemspec
+++ b/simplecov-cobertura.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'ci_reporter_test_unit', '~> 1.0'
+  spec.add_development_dependency 'libxml-ruby', '~> 2.7'
 
-  spec.add_runtime_dependency 'libxml-ruby', '~> 2.7'
   spec.add_runtime_dependency 'simplecov', '~> 0.8'
 end

--- a/test/simplecov-cobertura_test.rb
+++ b/test/simplecov-cobertura_test.rb
@@ -20,10 +20,9 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     assert_not_empty(xml)
     assert_equal(xml, IO.read(result_path))
   end
-  
+
   def test_format_dtd_validates
     xml = @formatter.format(@result)
-    
     dtd_text = open(SimpleCov::Formatter::CoberturaFormatter::DTD_URL) { |io| io.read }
     dtd = LibXML::XML::Dtd.new(dtd_text)
     doc = LibXML::XML::Document.string(xml)


### PR DESCRIPTION
Looks like this gem depends `libxml-ruby`, which requires `libxml` and C extensions, so it's not possible to use this gem with JRuby. I was able to replace the `libxml-ruby` dependency with `REXML`, which is pure Ruby and included in Ruby's standard library. The tests still rely on `libxml-ruby`, but the lib itself does not.