### PR TITLE
Generate a package per group

### DIFF
--- a/lib/simplecov-cobertura.rb
+++ b/lib/simplecov-cobertura.rb
@@ -27,24 +27,27 @@ class SimpleCov::Formatter::CoberturaFormatter
     source << SimpleCov.root
 
     coverage << packages = LibXML::XML::Node.new('packages')
-    packages << package = LibXML::XML::Node.new('package')
-    set_package_attributes(package, result)
 
-    package << classes = LibXML::XML::Node.new('classes')
+    result.groups.map do |name, files|
+        packages << package = LibXML::XML::Node.new('package')
+        set_package_attributes(package, name, files)
 
-    result.files.each do |file|
-      classes << class_ = LibXML::XML::Node.new('class')
-      set_class_attributes(class_, file)
+        package << classes = LibXML::XML::Node.new('classes')
 
-      class_ << LibXML::XML::Node.new('methods')
-      class_ << lines = LibXML::XML::Node.new('lines')
+        files.each do |file|
+          classes << class_ = LibXML::XML::Node.new('class')
+          set_class_attributes(class_, file)
 
-      file.lines.each do |file_line|
-        if file_line.covered? || file_line.missed?
-          lines << line = LibXML::XML::Node.new('line')
-          set_line_attributes(line, file_line)
+          class_ << LibXML::XML::Node.new('methods')
+          class_ << lines = LibXML::XML::Node.new('lines')
+
+          file.lines.each do |file_line|
+            if file_line.covered? || file_line.missed?
+              lines << line = LibXML::XML::Node.new('line')
+              set_line_attributes(line, file_line)
+            end
+          end
         end
-      end
     end
 
     set_xml_head(doc.to_s)
@@ -63,9 +66,9 @@ class SimpleCov::Formatter::CoberturaFormatter
     coverage['timestamp'] = Time.now.to_i.to_s
   end
   
-  def set_package_attributes(package, result)
-    package['name'] = 'simplecov-cobertura'
-    package['line-rate'] = (result.covered_percent/100).round(2).to_s
+  def set_package_attributes(package, name, files)
+    package['name'] = name
+    package['line-rate'] = (files.covered_percent/100).round(2).to_s
     package['branch-rate'] = '0'
     package['complexity'] = '0'
   end

--- a/shippable.yml
+++ b/shippable.yml
@@ -14,6 +14,6 @@ cache: true
 notifications:
   email:
     recipients:
-      - jbowes@dashingrocket.com
+      - ivailop@s2technologies.com
     on_success: change
     on_failure: always

--- a/simplecov-cobertura.gemspec
+++ b/simplecov-cobertura.gemspec
@@ -4,12 +4,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'simplecov-cobertura'
-  spec.version       = '1.0.3.alpha.0'
-  spec.authors       = ['Jesse Bowes']
-  spec.email         = ['jbowes@dashingrocket.com']
+  spec.version       = '1.0.3.alpha.1'
+  spec.authors       = ['Ivailo Petrov']
+  spec.email         = ['ivailop@s2technologies.com']
   spec.summary       = 'SimpleCov Cobertura Formatter'
   spec.description   = 'Produces Cobertura XML formatted output from SimpleCov'
-  spec.homepage      = 'https://github.com/dashingrocket/simplecov-cobertura'
+  spec.homepage      = 'https://github.com/s2technologies/simplecov-cobertura'
   spec.license       = 'Apache-2.0'
   spec.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
When working on big projects (with many files) it is very hard to navigate/review a flat file list coverage report. Splitting the list in groups makes the report much better organized and also provides a very convenient per group `line-rate`.