### PR TITLE
Relax JSON dependency to allow 2.x

### DIFF
--- a/simplecov-cobertura.gemspec
+++ b/simplecov-cobertura.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'nokogiri', '~> 1.6'
 
   spec.add_dependency 'simplecov', '~> 0.8'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency "json", ">= 1.8", "< 3"
 end


### PR DESCRIPTION
Simplecov also changed this a while ago:

https://github.com/colszowka/simplecov/commit/b47a3bd33d70f90ea2339ec2cef2c7427a6cb825