### PR TITLE
Fix keyword argument warnings for specs for Ruby 2.7

### DIFF
--- a/test/simplecov-cobertura_test.rb
+++ b/test/simplecov-cobertura_test.rb
@@ -7,9 +7,8 @@ require 'simplecov'
 require 'simplecov-cobertura'
 
 class CoberturaFormatterTest < Test::Unit::TestCase
-
   def setup
-    @result = SimpleCov::Result.new("#{__FILE__}" => [1,2])
+    @result = SimpleCov::Result.new({ "#{__FILE__}" => [1,2] })
     @formatter = SimpleCov::Formatter::CoberturaFormatter.new
   end
 


### PR DESCRIPTION
When running specs via `RUBYOPT="-W:deprecated" rake` Ruby 2.7 emits
with following warnings:

```
<path>/test/simplecov-cobertura_test.rb:12:
warning: Passing the keyword argument as the last hash parameter is
deprecated
<path>/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/simplecov-0.19.1/lib/simplecov/result.rb:28:
warning: The called method `initialize' is defined here

```
This commit fixes the warning.

See also
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

## Screenshots

Console output before and after when running Ruby 2.7 with `RUBYOPT="-W:depricated"`:

| Before | After |
| -- | -- |
|  ![Screenshot from 2020-11-19 13-20-32](https://user-images.githubusercontent.com/28908/99665568-17da1400-2a6a-11eb-967a-da032647b84f.png) |  ![Screenshot from 2020-11-19 13-20-47](https://user-images.githubusercontent.com/28908/99665580-1dcff500-2a6a-11eb-8241-2c763501afc2.png) |
