### PR TITLE
Add support for custom report filename

### DIFF
--- a/lib/simplecov-cobertura.rb
+++ b/lib/simplecov-cobertura.rb
@@ -12,9 +12,13 @@ module SimpleCov
       RESULT_FILE_NAME = 'coverage.xml'
       DTD_URL = 'http://cobertura.sourceforge.net/xml/coverage-04.dtd'
 
+      def initialize(result_file_name: RESULT_FILE_NAME)
+        @result_file_name = result_file_name
+      end
+
       def format(result)
         xml_doc = result_to_xml result
-        result_path = File.join(SimpleCov.coverage_path, RESULT_FILE_NAME)
+        result_path = File.join(SimpleCov.coverage_path, @result_file_name)
 
         formatter = REXML::Formatters::Pretty.new
         formatter.compact = true

--- a/test/simplecov-cobertura_test.rb
+++ b/test/simplecov-cobertura_test.rb
@@ -35,6 +35,13 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     assert_equal(xml, IO.read(result_path))
   end
 
+  def test_format_save_custom_filename
+    xml = SimpleCov::Formatter::CoberturaFormatter.new(result_file_name: 'cobertura.xml').format(@result)
+    result_path = File.join(SimpleCov.coverage_path, 'cobertura.xml')
+    assert_not_empty(xml)
+    assert_equal(xml, IO.read(result_path))
+  end
+
   def test_terminal_output
     output, _ = capture_output { @formatter.format(@result) }
     result_path = File.join(SimpleCov.coverage_path, SimpleCov::Formatter::CoberturaFormatter::RESULT_FILE_NAME)


### PR DESCRIPTION
**What**
This PR add support for custom report filenames.

**Why**
We use [Codacy](https://www.codacy.com/product) and there reporter is expecting a filename of `cobertura.xml`
https://github.com/codacy/codacy-coverage-reporter/blob/a6b918179125a474d1ea0b0b581859920348cfba/src/main/scala/com/codacy/rules/ReportRules.scala#L210

My hack for the longest time has been to redefine the constant.
 ```
  SimpleCov::Formatter::CoberturaFormatter::RESULT_FILE_NAME = "cobertura.xml".freeze
  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
```
It works but ruby complains...

```
/app/vendor/bundle/ruby/3.0.0/gems/simplecov-cobertura-2.0.0/lib/simplecov-cobertura.rb:12: warning: previous definition of RESULT_FILE_NAME was here
```
