### PR TITLE
Use filename as classname

### DIFF
--- a/lib/simplecov-cobertura.rb
+++ b/lib/simplecov-cobertura.rb
@@ -116,7 +116,7 @@ module SimpleCov
           bs = file.coverage_statistics[:branch]
 
           filename = file.filename
-          class_.attributes['name'] = File.basename(filename, '.*')
+          class_.attributes['name'] = resolve_filename(filename)
           class_.attributes['filename'] = resolve_filename(filename)
           class_.attributes['line-rate'] = extract_rate(ls.percent)
           if SimpleCov.branch_coverage?

--- a/test/simplecov-cobertura_test.rb
+++ b/test/simplecov-cobertura_test.rb
@@ -90,7 +90,7 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     classes = doc.xpath '/coverage/packages/package/classes/class'
     assert_equal 1, classes.length
     clazz = classes.first
-    assert_equal 'simplecov-cobertura_test', clazz.attribute('name').value
+    assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('name').value
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('filename').value
     assert_equal '0.86', clazz.attribute('line-rate').value
     assert_equal '0.5', clazz.attribute('branch-rate').value
@@ -140,7 +140,7 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     classes = doc.xpath '/coverage/packages/package/classes/class'
     assert_equal 1, classes.length
     clazz = classes.first
-    assert_equal 'simplecov-cobertura_test', clazz.attribute('name').value
+    assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('name').value
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('filename').value
     assert_equal '0.86', clazz.attribute('line-rate').value
     assert_equal '0.5', clazz.attribute('branch-rate').value
@@ -169,7 +169,7 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     classes = doc.xpath '/coverage/packages/package/classes/class'
     assert_equal 1, classes.length
     clazz = classes.first
-    assert_equal 'simplecov-cobertura_test', clazz.attribute('name').value
+    assert_equal "../#{expected_base}/test/simplecov-cobertura_test.rb", clazz.attribute('name').value
     assert_equal "../#{expected_base}/test/simplecov-cobertura_test.rb", clazz.attribute('filename').value
   ensure
     SimpleCov.root(old_root)


### PR DESCRIPTION
This change is to use the filename as the class name.  SimpleCov handles coverage based on file while Cobertura does it per class.  To mitigate this, use the full class name (including relative path) as the Cobertura class name.  

This also resolve #29 