### PR TITLE
Add 'require stringio' to root library file.

### DIFF
--- a/lib/simplecov-cobertura.rb
+++ b/lib/simplecov-cobertura.rb
@@ -1,3 +1,4 @@
+require 'stringio'
 require 'rexml/document'
 require 'rexml/element'
 require 'pathname'


### PR DESCRIPTION
Fixes #46 

...Potentially.

I admit I haven't had time to test this locally so this is speculative. And there could probably stand to be a test too. But it's what I am able to contribute right now.